### PR TITLE
Fixing #19

### DIFF
--- a/skd_smoke/__init__.py
+++ b/skd_smoke/__init__.py
@@ -210,8 +210,10 @@ def generate_test_method(urlname, status, method='GET', initialize=None,
             prepared_url_kwargs = url_kwargs(self)
         else:
             prepared_url_kwargs = url_kwargs or {}
-
-        resolved_url = resolve_url(urlname, **prepared_url_kwargs)
+        prepared_url_args = ()
+        if isinstance(prepared_url_kwargs, (list, tuple)):
+            prepared_url_args, prepared_url_kwargs = prepared_url_kwargs
+        resolved_url = resolve_url(urlname, *prepared_url_args, **prepared_url_kwargs)
 
         if user_credentials:
             if callable(user_credentials):


### PR DESCRIPTION
If `url_kwargs` is a tuple, assume that first and second elements are `args` and `kwargs` for `resolve_url`
