### PR TITLE
Make it easy to define default or global settings (such as user credentials)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,13 @@ django project.
 
 Configuration
 -------------
+
+Sub-class **SmokeTestCase** and configure your test using the *TESTS_CONFIGURATION*.  Further configure by defining
+optional *default_* attributes (or class methods).
+
+Basic Configuration
+********
+
 ``TESTS_CONFIGURATION`` of your ``TestCase`` should contain tuple/list of
 tuples for every request with the next structure:
 
@@ -96,6 +103,58 @@ you can use it to transfer state between them. But take into account that
 #. ``url_kwargs``
 #. ``user_credentials``
 #. ``request_data``
+
+Extra Configuration
+********
+
+For convenience, default values can be provided for some url configuration items.  If a URL test is defined which is
+missing a definition for one of these values, the class definition is searched for a default value and that is used, if
+present.
+
+For example, you may define *user_credentials* in a URL test. In cases where several URL tests have the same user
+credentials, it is more convenient to define the credentials one time, as a class attribute (or method). So in the case
+of user credentials, you can also define a class attribute like this, which will take effect for all test urls which
+dont have user_credentials defined. Like this:
+
+.. code-block:: python
+
+    class TestDemo(SmokeTestCase):
+        TESTS_CONFIGURATION = (
+            ('page1', 200, 'GET',),
+            ('page2', 200, 'GET',),
+            ('page3', 200, 'GET',),
+            ('page4', 200, 'GET', {
+                'user_credentials': {
+                    'username': 'other_user',
+                    'password': 'other_password',
+                }
+            }),
+            ('page5', 200, 'GET', {
+                'user_credentials': None,
+            }),
+        )
+
+        default_user_credentials = {
+            'username': 'my_user',
+            'password': 'my_password',
+        }
+
+
+In the example above, tests for page1, page2, and page3 will be run using the default credentials (*my_user*). The test
+for page4 will run with special credentials (*other_user*).  The test for page5 will run with no credentials, no logged
+in user.
+
+**Note:** these default values can be either class attributes *or* class methods (taking a ``self`` parameter).
+
+The full list of possible, default, attributes is:
+
+* default_comment
+* default_initialize
+* default_url_args
+* default_url_kwargs
+* default_request_data
+* default_user_credentials
+* default_redirect_to
 
 
 Examples

--- a/skd_smoke/__init__.py
+++ b/skd_smoke/__init__.py
@@ -331,13 +331,17 @@ class GenerateTestMethodsMeta(type):
             setattr(cls, fail_method_name, fail_method)
         else:
             for urlname, status, method, data in config:
-                comment = data.get('comment', None)
-                initialize = data.get('initialize', None)
-                url_args = data.get('url_args', None)
-                url_kwargs = data.get('url_kwargs', None)
-                request_data = data.get('request_data', None)
-                get_user_credentials = data.get('user_credentials', None)
-                redirect_to = data.get('redirect_to', None)
+                # For each config item, if it doesnt exist in config tuple's "data" then
+                # see if user has defined a default on the test class
+                find_conf = lambda name: data.get(name, getattr(cls, "default_" + name, None))
+
+                comment = find_conf('comment')
+                initialize = find_conf('initialize')
+                url_args = find_conf('url_args')
+                url_kwargs = find_conf('url_kwargs')
+                request_data = find_conf('request_data')
+                get_user_credentials = find_conf('user_credentials')
+                redirect_to = find_conf('redirect_to')
                 status_text = STATUS_CODE_TEXT.get(status, 'UNKNOWN')
 
                 test_method_name = prepare_test_name(urlname, method, status)

--- a/skd_smoke/__init__.py
+++ b/skd_smoke/__init__.py
@@ -313,11 +313,11 @@ class GenerateTestMethodsMeta(type):
         cls = super(GenerateTestMethodsMeta, mcs).__new__(
             mcs, name, bases, attrs)
 
-        # Ensure test method generation is only performed for subclasses of
-        # GenerateTestMethodsMeta (excluding GenerateTestMethodsMeta class
-        # itself).
-        parents = [b for b in bases if isinstance(b, GenerateTestMethodsMeta)]
-        if not parents:
+        # If this metaclass is instantiating something found in one of these modules
+        # then we skip generation of test cases, etc.  Without this, we will erroneously
+        # detect error case of TESTS_CONFIGURATION being None
+        skip_modules = ['skd_smoke', ]
+        if attrs.get('__module__', skip_modules[0]) in skip_modules:
             return cls
 
         # noinspection PyBroadException

--- a/skd_smoke/__init__.py
+++ b/skd_smoke/__init__.py
@@ -211,7 +211,7 @@ def generate_test_method(urlname, status, method='GET', initialize=None,
         into http method request
     :param user_credentials: dict or callable object which returns dict to \
         login user using ``TestCase.client.login``
-    :param redirect_to: plain url which is checked if only expected status \
+    :param redirect_to: plain url or callable which is checked if only expected status \
         code is one of the [301, 302, 303, 307]
     :return: new test method
 
@@ -326,8 +326,10 @@ class GenerateTestMethodsMeta(type):
         # If this metaclass is instantiating something found in one of these modules
         # then we skip generation of test cases, etc.  Without this, we will erroneously
         # detect error case of TESTS_CONFIGURATION being None
+        # Also, skip certain classes based on class name
         skip_modules = ['skd_smoke', ]
-        if attrs.get('__module__', skip_modules[0]) in skip_modules:
+        skip_names = ['NewBase', 'SmokeTestCase', ]
+        if attrs.get('__module__') in skip_modules or name in skip_names:
             return cls
 
         # noinspection PyBroadException

--- a/skd_smoke_tests/tests.py
+++ b/skd_smoke_tests/tests.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals, print_function
 import types
 from unittest import TestCase
+from django import VERSION
 
 from mock import Mock, patch
 from django.core.exceptions import ImproperlyConfigured
@@ -236,9 +237,14 @@ class SmokeTestCaseTestCase(TestCase):
             login_mock.assert_called_once_with(**user_credentials)
 
         if redirect_to:
-            testcase_mock.assertRedirects.assert_called_once_with(
-                response, redirect_to, fetch_redirect_response=False
-            )
+            if VERSION >= (1, 7):
+                testcase_mock.assertRedirects.assert_called_once_with(
+                    response, redirect_to, fetch_redirect_response=False
+                )
+            else:
+                testcase_mock.assertRedirects.assert_called_once_with(
+                    response, redirect_to
+                )
         else:
             testcase_mock.assertRedirects.assert_not_called()
 


### PR DESCRIPTION
Make it easy to define default or global settings (such as user credentials) by attaching default values to the class instead of having to define the same values over and over in each test URL definition

Update documentation to explain the new 'defaults' feature
